### PR TITLE
Update extension to work with modern gnome shell

### DIFF
--- a/douailleerwan@gmail.com/brightness.frag
+++ b/douailleerwan@gmail.com/brightness.frag
@@ -1,8 +1,3 @@
-uniform int height;
-uniform int width;
-uniform int mouseX;
-uniform int mouseY;
-
 uniform float slider;
 
 uniform sampler2D tex;

--- a/douailleerwan@gmail.com/default.frag
+++ b/douailleerwan@gmail.com/default.frag
@@ -1,8 +1,3 @@
-uniform int height;
-uniform int width;
-uniform int mouseX;
-uniform int mouseY;
-
 uniform sampler2D tex;
 
 void main()

--- a/douailleerwan@gmail.com/extension.js
+++ b/douailleerwan@gmail.com/extension.js
@@ -25,16 +25,18 @@ const ShaderMenu       = Me.imports.shaderMenu;
 const ShaderModifier = Me.imports.shaderModifier;
 
 let shaderMenu;
+let shaderModifier;
 
 function init(metadata) {
 }
 
 function enable() {
-  let shaderModifier = new ShaderModifier.ShaderModifier(global.stage);
+  shaderModifier = new ShaderModifier.ShaderModifier(global.stage);
   shaderMenu = new ShaderMenu.ShaderMenu(shaderModifier);
   Main.panel.addToStatusArea('shaderMenu', shaderMenu);
 }
 
 function disable() {
   shaderMenu.destroy();
+  shaderModifier.destroy();
 };

--- a/douailleerwan@gmail.com/medianFilter.frag
+++ b/douailleerwan@gmail.com/medianFilter.frag
@@ -1,7 +1,5 @@
 uniform int height;
 uniform int width;
-uniform int mouseX;
-uniform int mouseY;
 
 uniform float slider;
 
@@ -13,20 +11,22 @@ void main()
   float countR = 0.0;
   float countG = 0.0;
   float countB = 0.0;
-  int area = int(round(2.0 * slider))+1;
+  int samples=0;
+  int area = int(5.0 * slider)+1;
 
-  for(dX = -area; dX <= area; ++dX) {
-    for(dY = -area; dY <= area; ++dY) {
+  for(dX = -(area+1)/2; dX <= area/2; ++dX) {
+    for(dY = -(area+1)/2; dY <= area/2; ++dY) {
       vec2 pixel = cogl_tex_coord_in[0].xy;
       vec3 color = texture2D( tex, vec2((pixel.x*width+dX)/width,
                                         (pixel.y*height+dY)/height)).rgb;
       countR += color.x;
       countG += color.y;
       countB += color.z;
+      samples += 1;
     }
   }
-  cogl_color_out = vec4(countR/((area*2.0+1.0)*(area*2.0+1.0)),
-                        countG/((area*2.0+1.0)*(area*2.0+1.0)),
-                        countB/((area*2.0+1.0)*(area*2.0+1.0)),
+  cogl_color_out = vec4(countR/samples,
+                        countG/samples,
+                        countB/samples,
                         1.0);
 }

--- a/douailleerwan@gmail.com/metadata.json
+++ b/douailleerwan@gmail.com/metadata.json
@@ -1,1 +1,1 @@
-{"description": "Shader menu", "shell-version": ["3.18.3"], "name": "Shader menu", "uuid": "douailleerwan@gmail.com"}
+{"description": "Shader menu", "shell-version": ["42.2"], "name": "Shader menu", "uuid": "douailleerwan@gmail.com"}

--- a/douailleerwan@gmail.com/negative.frag
+++ b/douailleerwan@gmail.com/negative.frag
@@ -1,8 +1,3 @@
-uniform int height;
-uniform int width;
-uniform int mouseX;
-uniform int mouseY;
-
 uniform float slider;
 
 uniform sampler2D tex;

--- a/douailleerwan@gmail.com/pikachu.frag
+++ b/douailleerwan@gmail.com/pikachu.frag
@@ -1,10 +1,3 @@
-uniform int height;
-uniform int width;
-uniform int mouseX;
-uniform int mouseY;
-
-uniform float slider;
-
 uniform sampler2D tex;
 
 #define _  0.

--- a/douailleerwan@gmail.com/pixelColoration.frag
+++ b/douailleerwan@gmail.com/pixelColoration.frag
@@ -1,8 +1,3 @@
-uniform int height;
-uniform int width;
-uniform int mouseX;
-uniform int mouseY;
-
 uniform float slider;
 
 uniform sampler2D tex;

--- a/douailleerwan@gmail.com/shaderList.js
+++ b/douailleerwan@gmail.com/shaderList.js
@@ -23,7 +23,7 @@ const Gio = imports.gi.Gio;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me             = ExtensionUtils.getCurrentExtension();
 
-const ShaderList = new Lang.Class({
+var ShaderList = new Lang.Class({
   Name : 'ShaderList',
 
   _init : function() {

--- a/douailleerwan@gmail.com/shaderModifier.js
+++ b/douailleerwan@gmail.com/shaderModifier.js
@@ -26,28 +26,37 @@ const Lang = imports.lang;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me             = ExtensionUtils.getCurrentExtension();
 
-const ShaderModifier = new Lang.Class({
-  Name : 'ShaderModifier',
+const unused = Symbol('unused');
 
-  _init : function(actor) {
+var ShaderModifier = class ShaderModifier {
+
+  constructor(actor) {
     this._actor = actor;
+
     this._currentShader = {name : "default", fileName : "default.frag" } ;
     this._sliderValue = 0.0;
     this._date = new GLib.DateTime();
-    this._applyCurrentShader();
-  },
 
-  _changeShader : function(shaderItem) {
+    // we deliberately don't apply a shader on construction because
+    // if the user has a broken gl compiler or otherwise broken system then
+    // the whole screen will freeze.   When that happens, if the user reboots their system and the shader
+    // is applied again at startup, it makes recovery very hard for them.   This way, nothing is applied
+    // till the menu is used.
+  }
+
+  _changeShader(shaderItem) {
     this._removeShader();
     this._currentShader = shaderItem;
     this._applyCurrentShader();
-  },
+  }
 
-  _applyCurrentShader : function() {
+  _applyCurrentShader() {
+      this._properties={};
       try {
         this._shaderSource = Shell.get_file_contents_utf8_sync(Me.path + "/" + this._currentShader.fileName);
       } catch (e) {
-        this._shaderSourcer = null;
+        this._shaderSource = null;
+        return;
       }
 
       if(this._actor) {
@@ -56,37 +65,58 @@ const ShaderModifier = new Lang.Class({
           this._fx = new Clutter.ShaderEffect({
             shader_type: Clutter.ShaderType.FRAGMENT_SHADER });
           this._fx.set_shader_source(this._shaderSource);
-          this._fx.set_uniform_value('height', this._actor.get_height());
-          this._fx.set_uniform_value('width', this._actor.get_width());
-          this._fx.set_uniform_value('slider', this._sliderValue);
+          this._newFrame();
           this._actor.add_effect_with_name('shader',  this._fx);
 
-          this._timeline = new Clutter.Timeline({ duration: 1, repeat_count: -1 });
-          this._timeline.connect('new-frame', Lang.bind(this, this._newFrame));
-          this._timeline.start();
+          this._actor.connect('after-paint', Lang.bind(this, this._newFrame));
         }
       }
-  },
-
-  _newFrame: function() {
-    this._fx.set_uniform_value('height', this._actor.get_height());
-    this._fx.set_uniform_value('width', this._actor.get_width());
-    this._fx.set_uniform_value('mouseX',global.get_pointer()[0]);
-    this._fx.set_uniform_value('mouseY',global.get_pointer()[1]);
-    this._fx.set_uniform_value('globalTime', (new GLib.DateTime()).get_seconds());
-    this._fx.set_uniform_value('slider', this._sliderValue);
-    this._actor.scale_y = 1.0;
-  },
-
-  _removeShader : function() {
-    this._removeShaderNamed('shader');
-  },
-
-  _removeShaderNamed : function(aShaderName) {
-    this._actor.remove_effect_by_name(aShaderName);
-  },
-
-  updateSliderValue : function(value) {
-    this._sliderValue = value;
   }
-});
+
+  // save substantial amounts of CPU by only setting values that are used in the shader, and only if they changed.
+  _setProperty(name, value) {
+    if (!this._properties.hasOwnProperty(name)) {
+      if (!this._shaderSource.includes(name)) {
+        this._properties[name] = unused;
+      }
+    }
+    if (this._properties[name]!=value && this._properties[name]!=unused) {
+      this._properties[name] = value;
+      this._fx.set_uniform_value(name, value);
+    }
+  }
+  _newFrame() {
+    if (!this._fx) return;
+
+    this._setProperty('height', this._actor.get_height());
+    this._setProperty('width', this._actor.get_width());
+    this._setProperty('mouseX',global.get_pointer()[0]);
+    this._setProperty('mouseY',global.get_pointer()[1]);
+    this._setProperty('globalTime', (new GLib.DateTime()).get_seconds());
+    this._setProperty('slider', this._sliderValue);
+    this._actor.scale_y = 1.0;
+
+  }
+
+  _removeShader() {
+    this._removeShaderNamed('shader');
+  }
+
+  destroy() {
+    this._removeShader();
+  }
+
+  _removeShaderNamed(aShaderName) {
+    this._actor.remove_effect_by_name(aShaderName);
+  }
+
+  updateSliderValue(value) {
+    this._sliderValue = value;
+    this._newFrame();
+  }
+
+  hasSlider() {
+
+    return this._shaderSource && this._shaderSource.includes('slider');
+  }
+};


### PR DESCRIPTION
This makes the extension with gnome shell 42 (and maybe a few newer and older versions).

It also fixes a few of the most critical bugs users were complaining about (permanent screen freeze that even a reboot didn't fix), and a few bugs I noticed (extension does not disable properly, slider sometimes doesn't work, median filtering broken).



I know you haven't touched this in 6 years...    if you no longer want to maintain it, do put a note saying so in the readme and I shall fork it.